### PR TITLE
feat(proxy): mitmproxy addon with request() hook for domain/IP filtering

### DIFF
--- a/proxy/aegis_addon.py
+++ b/proxy/aegis_addon.py
@@ -1,0 +1,81 @@
+import ipaddress
+import logging
+import os
+import socket
+from pathlib import Path
+
+from mitmproxy import http
+
+from proxy.rules_loader import load_c2_blocklist, load_domain_whitelist, load_rules
+from proxy.utils import block_flow, generate_request_id
+
+logger = logging.getLogger("aegis-proxy")
+
+RULES_PATH = Path(os.getenv("AEGIS_RULES_PATH", "/opt/aegis/rules"))
+
+_BINARY_EXTENSIONS = (
+    ".exe", ".msi", ".deb", ".rpm", ".pkg", ".dmg",
+    ".tar.gz", ".tgz", ".tar.bz2", ".zip", ".gz", ".xz",
+    ".bin", ".sh", ".run", ".appimage",
+)
+
+
+class AegisAddon:
+    def __init__(self):
+        self.domain_whitelist: set[str] = set()
+        self.c2_blocklist: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        self.rules: dict = {}
+        self._load_rules()
+
+    def _load_rules(self):
+        try:
+            self.domain_whitelist = load_domain_whitelist(RULES_PATH / "domain_whitelist.txt")
+            logger.info("Loaded %d whitelisted domains", len(self.domain_whitelist))
+        except FileNotFoundError:
+            logger.warning("domain_whitelist.txt not found, using empty whitelist")
+
+        try:
+            self.c2_blocklist = load_c2_blocklist(RULES_PATH / "c2_blocklist.txt")
+            logger.info("Loaded %d C2 blocklist networks", len(self.c2_blocklist))
+        except FileNotFoundError:
+            logger.warning("c2_blocklist.txt not found, using empty blocklist")
+
+        try:
+            self.rules = load_rules(RULES_PATH / "rules.yml")
+            patterns = self.rules.get("dangerous_patterns", [])
+            logger.info("Loaded %d dangerous patterns", len(patterns))
+        except FileNotFoundError:
+            logger.warning("rules.yml not found, using empty rules")
+
+    def _is_c2_ip(self, host: str) -> bool:
+        try:
+            addrs = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        except socket.gaierror:
+            return False
+
+        for _, _, _, _, sockaddr in addrs:
+            ip = ipaddress.ip_address(sockaddr[0])
+            for network in self.c2_blocklist:
+                if ip in network:
+                    return True
+        return False
+
+    def _is_binary_download(self, flow: http.HTTPFlow) -> bool:
+        path = flow.request.path.lower()
+        return any(path.endswith(ext) for ext in _BINARY_EXTENSIONS)
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        request_id = generate_request_id()
+        flow.metadata["aegis_request_id"] = request_id
+        host = flow.request.pretty_host.lower()
+
+        if self._is_c2_ip(host):
+            block_flow(flow, "c2_ip_blocked", request_id)
+            return
+
+        if self._is_binary_download(flow) and host not in self.domain_whitelist:
+            block_flow(flow, "domain_not_whitelisted", request_id)
+            return
+
+
+addons = [AegisAddon()]

--- a/proxy/rules_loader.py
+++ b/proxy/rules_loader.py
@@ -1,0 +1,31 @@
+import ipaddress
+from pathlib import Path
+
+import yaml
+
+
+def load_domain_whitelist(path: Path) -> set[str]:
+    lines = path.read_text().splitlines()
+    return {
+        s.lower()
+        for line in lines
+        if (s := line.strip()) and not s.startswith("#")
+    }
+
+
+def load_c2_blocklist(path: Path) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    lines = path.read_text().splitlines()
+    networks = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            networks.append(ipaddress.ip_network(line, strict=False))
+        except ValueError:
+            continue
+    return networks
+
+
+def load_rules(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())

--- a/proxy/utils.py
+++ b/proxy/utils.py
@@ -1,0 +1,40 @@
+import json
+import logging
+import time
+import uuid
+
+from mitmproxy import http
+
+logger = logging.getLogger("aegis-proxy")
+
+
+def generate_request_id() -> str:
+    return f"req_{uuid.uuid4().hex[:12]}"
+
+
+def block_flow(flow: http.HTTPFlow, reason: str, request_id: str, pattern_matched: str | None = None) -> None:
+    """Set 403 response on flow and emit structured log."""
+    body = json.dumps({
+        "request_id": request_id,
+        "action": "block",
+        "reason": reason,
+        "url": flow.request.pretty_url,
+    })
+    flow.response = http.Response.make(
+        403,
+        body.encode(),
+        {"Content-Type": "application/json", "X-Aegis-Request-Id": request_id},
+    )
+
+    event = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "request_id": request_id,
+        "action": "block",
+        "reason": reason,
+        "method": flow.request.method,
+        "url": flow.request.pretty_url,
+        "source": "aegis-proxy",
+    }
+    if pattern_matched:
+        event["pattern_matched"] = pattern_matched
+    logger.warning("%s", json.dumps(event))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,5 @@ dev = [
     "uvicorn>=0.34",
     "python-multipart>=0.0.20",
     "pyyaml>=6.0",
+    "mitmproxy>=11.0",
 ]

--- a/tests/test_request_hook.py
+++ b/tests/test_request_hook.py
@@ -1,0 +1,94 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from proxy.aegis_addon import AegisAddon
+
+
+def _make_flow(url: str = "https://example.com/page.html", host: str = "example.com"):
+    flow = MagicMock()
+    flow.request.pretty_url = url
+    flow.request.pretty_host = host
+    flow.request.path = url.split(host, 1)[-1] if host in url else "/"
+    flow.request.method = "GET"
+    flow.response = None
+    flow.metadata = {}
+    return flow
+
+
+@pytest.fixture
+def addon(tmp_path):
+    whitelist = tmp_path / "domain_whitelist.txt"
+    whitelist.write_text("github.com\nregistry.npmjs.org\n")
+
+    blocklist = tmp_path / "c2_blocklist.txt"
+    blocklist.write_text("198.51.100.0/24\n")
+
+    rules = tmp_path / "rules.yml"
+    rules.write_text("dangerous_patterns: []\n")
+
+    with patch("proxy.aegis_addon.RULES_PATH", tmp_path):
+        return AegisAddon()
+
+
+class TestRequestHookDomainWhitelist:
+    def test_html_from_any_domain_allowed(self, addon):
+        flow = _make_flow("https://unknown.com/page.html", "unknown.com")
+        addon.request(flow)
+        assert flow.response is None
+
+    def test_binary_from_whitelisted_domain_allowed(self, addon):
+        flow = _make_flow("https://github.com/release.tar.gz", "github.com")
+        addon.request(flow)
+        assert flow.response is None
+
+    def test_binary_from_unknown_domain_blocked(self, addon):
+        flow = _make_flow("https://evil.com/malware.tar.gz", "evil.com")
+        addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["reason"] == "domain_not_whitelisted"
+
+    def test_exe_from_unknown_domain_blocked(self, addon):
+        flow = _make_flow("https://evil.com/setup.exe", "evil.com")
+        addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+
+
+class TestRequestHookC2Blocklist:
+    def test_c2_ip_blocked(self, addon):
+        flow = _make_flow("https://c2server.com/callback", "c2server.com")
+        # Mock DNS resolution to return a C2 IP
+        mock_addr = [(None, None, None, None, ("198.51.100.5", 443))]
+        with patch("socket.getaddrinfo", return_value=mock_addr):
+            addon.request(flow)
+        assert flow.response is not None
+        assert flow.response.status_code == 403
+        body = json.loads(flow.response.content)
+        assert body["reason"] == "c2_ip_blocked"
+
+    def test_safe_ip_allowed(self, addon):
+        flow = _make_flow("https://safe.com/page.html", "safe.com")
+        mock_addr = [(None, None, None, None, ("93.184.216.34", 443))]
+        with patch("socket.getaddrinfo", return_value=mock_addr):
+            addon.request(flow)
+        assert flow.response is None
+
+    def test_dns_failure_allowed(self, addon):
+        """DNS failure should not block — fail open for DNS only."""
+        flow = _make_flow("https://unknown.com/page", "unknown.com")
+        import socket
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror):
+            addon.request(flow)
+        assert flow.response is None
+
+
+class TestRequestHookMetadata:
+    def test_request_id_set(self, addon):
+        flow = _make_flow()
+        addon.request(flow)
+        assert "aegis_request_id" in flow.metadata
+        assert flow.metadata["aegis_request_id"].startswith("req_")

--- a/tests/test_rules_loader.py
+++ b/tests/test_rules_loader.py
@@ -1,0 +1,72 @@
+import ipaddress
+
+from proxy.rules_loader import load_c2_blocklist, load_domain_whitelist, load_rules
+
+
+class TestLoadDomainWhitelist:
+    def test_basic(self, tmp_path):
+        f = tmp_path / "whitelist.txt"
+        f.write_text("github.com\npypi.org\n")
+        result = load_domain_whitelist(f)
+        assert result == {"github.com", "pypi.org"}
+
+    def test_comments_and_blanks(self, tmp_path):
+        f = tmp_path / "whitelist.txt"
+        f.write_text("# comment\n\ngithub.com\n  # another\n\npypi.org\n")
+        result = load_domain_whitelist(f)
+        assert result == {"github.com", "pypi.org"}
+
+    def test_case_insensitive(self, tmp_path):
+        f = tmp_path / "whitelist.txt"
+        f.write_text("GitHub.COM\n")
+        result = load_domain_whitelist(f)
+        assert "github.com" in result
+
+    def test_strips_whitespace(self, tmp_path):
+        f = tmp_path / "whitelist.txt"
+        f.write_text("  github.com  \n")
+        result = load_domain_whitelist(f)
+        assert "github.com" in result
+
+
+class TestLoadC2Blocklist:
+    def test_basic(self, tmp_path):
+        f = tmp_path / "blocklist.txt"
+        f.write_text("198.51.100.0/24\n203.0.113.0/24\n")
+        result = load_c2_blocklist(f)
+        assert len(result) == 2
+        assert ipaddress.ip_network("198.51.100.0/24") in result
+
+    def test_comments_and_blanks(self, tmp_path):
+        f = tmp_path / "blocklist.txt"
+        f.write_text("# comment\n\n198.51.100.0/24\n")
+        result = load_c2_blocklist(f)
+        assert len(result) == 1
+
+    def test_invalid_entries_skipped(self, tmp_path):
+        f = tmp_path / "blocklist.txt"
+        f.write_text("198.51.100.0/24\nnot-a-cidr\n203.0.113.0/24\n")
+        result = load_c2_blocklist(f)
+        assert len(result) == 2
+
+    def test_ipv6(self, tmp_path):
+        f = tmp_path / "blocklist.txt"
+        f.write_text("2001:db8::/32\n")
+        result = load_c2_blocklist(f)
+        assert len(result) == 1
+        assert ipaddress.ip_network("2001:db8::/32") in result
+
+
+class TestLoadRules:
+    def test_valid_yaml(self, tmp_path):
+        f = tmp_path / "rules.yml"
+        f.write_text(
+            "dangerous_patterns:\n"
+            "  - name: test\n"
+            "    pattern: 'curl.*|.*bash'\n"
+            "    severity: critical\n"
+            "    description: test pattern\n"
+        )
+        result = load_rules(f)
+        assert len(result["dangerous_patterns"]) == 1
+        assert result["dangerous_patterns"][0]["name"] == "test"


### PR DESCRIPTION
## Summary

- `proxy/rules_loader.py`: ルールファイルパーサー (whitelist, C2 blocklist, rules.yml)
- `proxy/utils.py`: request ID 生成、403 ブロックレスポンス生成、構造化ログ出力
- `proxy/aegis_addon.py`: `AegisAddon` class + `request()` hook
  - C2 IP blocklist: DNS 解決 + CIDR マッチング
  - Domain whitelist: バイナリダウンロード URL のみ対象
  - 403 レスポンス + JSON body (reason, request_id, url)
- `tests/test_rules_loader.py`: 9 テスト
- `tests/test_request_hook.py`: 8 テスト

Closes #5

## Test plan

- [x] `pytest tests/` — 55 tests passed
- [x] ホワイトリスト外ドメインからのバイナリ DL → 403
- [x] C2 IP → 403
- [x] 通常の HTML リクエスト → 通過
- [x] DNS 解決失敗 → 通過（fail open for DNS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)