### PR TITLE
feat(scanner): Dockerfile with ClamAV + Trivy installation

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clamav \
+    clamav-daemon \
+    clamav-freshclam \
+    curl \
+    netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Trivy
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+COPY scanner/clamd.conf /etc/clamav/clamd.conf
+RUN mkdir -p /var/lib/clamav && chown clamav:clamav /var/lib/clamav \
+    && sed -i 's|^DatabaseMirror.*|DatabaseMirror database.clamav.net|' /etc/clamav/freshclam.conf || true
+
+COPY scanner/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+COPY scanner/ /opt/aegis/scanner/
+RUN chmod +x /opt/aegis/scanner/entrypoint.sh
+
+WORKDIR /opt/aegis
+
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/aegis/scanner/entrypoint.sh"]

--- a/scanner/clamd.conf
+++ b/scanner/clamd.conf
@@ -1,0 +1,6 @@
+TCPSocket 3310
+TCPAddr 0.0.0.0
+Foreground yes
+MaxFileSize 50M
+MaxScanSize 100M
+DatabaseDirectory /var/lib/clamav

--- a/scanner/entrypoint.sh
+++ b/scanner/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+DB_DIR="/var/lib/clamav"
+if [ ! -f "$DB_DIR/main.cvd" ] && [ ! -f "$DB_DIR/main.cld" ]; then
+    echo "ClamAV DB not found, running freshclam..."
+    if ! freshclam --quiet; then
+        echo "ERROR: freshclam failed and no existing DB available"
+        exit 1
+    fi
+else
+    INTERVAL="${FRESHCLAM_INTERVAL:-21600}"
+    DB_AGE=$(( $(date +%s) - $(stat -c %Y "$DB_DIR/main.cvd" 2>/dev/null || stat -c %Y "$DB_DIR/main.cld" 2>/dev/null || echo 0) ))
+    if [ "$DB_AGE" -gt "$INTERVAL" ]; then
+        echo "ClamAV DB is stale ($DB_AGE seconds old), updating..."
+        freshclam --quiet || echo "Warning: freshclam failed, using existing DB"
+    fi
+fi
+
+clamd --config-file=/etc/clamav/clamd.conf &
+
+echo "Waiting for clamd..."
+for i in {1..60}; do
+    if echo PING | nc -w 1 localhost 3310 2>/dev/null | grep -q PONG; then
+        echo "clamd is ready"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "ERROR: clamd did not become ready in 60 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+
+TRIVY_CACHE="${TRIVY_CACHE_DIR:-/root/.cache/trivy}"
+if [ ! -d "$TRIVY_CACHE/db" ]; then
+    echo "Downloading Trivy DB..."
+    trivy --quiet --cache-dir "$TRIVY_CACHE" image --download-db-only 2>/dev/null || echo "Warning: Trivy DB download failed"
+fi
+
+exec uvicorn scanner.main:app --host 0.0.0.0 --port 8080 --workers "${AEGIS_WORKERS:-2}"

--- a/scanner/scanners/clamav.py
+++ b/scanner/scanners/clamav.py
@@ -1,39 +1,45 @@
-import subprocess
+import socket
+import struct
 from pathlib import Path
 
 from scanner.config import CLAMD_HOST, CLAMD_PORT, SCAN_TIMEOUT
 from scanner.models import ScanDetail, Verdict
 
+_CHUNK_SIZE = 8192
+
 
 def scan(file_path: Path) -> tuple[Verdict, ScanDetail]:
+    """Scan a file by streaming it to clamd via TCP INSTREAM command."""
     try:
-        result = subprocess.run(
-            ["clamdscan", "--stream", f"--stream-host={CLAMD_HOST}", f"--stream-port={CLAMD_PORT}",
-             "--no-summary", str(file_path)],
-            capture_output=True,
-            text=True,
-            timeout=SCAN_TIMEOUT / 1000,
-        )
-    except subprocess.TimeoutExpired:
+        with socket.create_connection((CLAMD_HOST, CLAMD_PORT), timeout=SCAN_TIMEOUT / 1000) as sock:
+            sock.sendall(b"zINSTREAM\0")
+
+            with open(file_path, "rb") as f:
+                while chunk := f.read(_CHUNK_SIZE):
+                    sock.sendall(struct.pack("!L", len(chunk)) + chunk)
+            # Send terminating zero-length chunk
+            sock.sendall(struct.pack("!L", 0))
+
+            response = b""
+            while data := sock.recv(4096):
+                response += data
+
+    except (TimeoutError, socket.timeout):
         return Verdict.block, ScanDetail(scanner="clamav", result="TIMEOUT")
-    except FileNotFoundError:
-        return Verdict.block, ScanDetail(scanner="clamav", result="ERROR", threat="clamdscan not found")
+    except (ConnectionRefusedError, OSError) as e:
+        return Verdict.block, ScanDetail(scanner="clamav", result="ERROR", threat=str(e))
 
-    output = result.stdout.strip()
+    result_str = response.decode("utf-8", errors="replace").strip().rstrip("\0")
 
-    if result.returncode == 1:
-        # Virus found — parse threat name from output like "file: ThreatName FOUND"
-        threat = "unknown"
-        if "FOUND" in output:
-            parts = output.rsplit(":", 1)
-            if len(parts) == 2:
-                threat = parts[1].strip().removesuffix("FOUND").strip()
-        return Verdict.block, ScanDetail(scanner="clamav", result="INFECTED", threat=threat)
-
-    if result.returncode == 0:
+    # clamd INSTREAM response format: "stream: OK" or "stream: ThreatName FOUND"
+    if result_str.endswith("OK"):
         return Verdict.allow, ScanDetail(scanner="clamav", result="OK")
 
-    # Any other return code is an error — fail-closed
-    return Verdict.block, ScanDetail(
-        scanner="clamav", result="ERROR", threat=output or result.stderr.strip()
-    )
+    if "FOUND" in result_str:
+        # Parse "stream: Win.Trojan.Agent-123 FOUND"
+        parts = result_str.rsplit(":", 1)
+        threat = parts[1].strip().removesuffix("FOUND").strip() if len(parts) == 2 else "unknown"
+        return Verdict.block, ScanDetail(scanner="clamav", result="INFECTED", threat=threat)
+
+    # Any other response — fail-closed
+    return Verdict.block, ScanDetail(scanner="clamav", result="ERROR", threat=result_str)

--- a/tests/test_scanner_pipeline.py
+++ b/tests/test_scanner_pipeline.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,13 +30,21 @@ class TestAggregateVerdict:
         assert aggregate_verdict(clamav, trivy) == expected
 
 
+def _mock_clamd_socket(response: bytes):
+    """Create a MagicMock socket returning a clamd response."""
+    mock_sock = MagicMock()
+    mock_sock.__enter__.return_value = mock_sock
+    mock_sock.recv.side_effect = [response, b""]
+    return mock_sock
+
+
 class TestClamavScanner:
     def test_clean_file(self, tmp_path):
         file = tmp_path / "clean.txt"
         file.write_text("hello world")
 
-        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="clean.txt: OK", stderr="")
-        with patch("subprocess.run", return_value=mock_result):
+        mock_sock = _mock_clamd_socket(b"stream: OK\0")
+        with patch("scanner.scanners.clamav.socket.create_connection", return_value=mock_sock):
             verdict, detail = clamav_scanner.scan(file)
 
         assert verdict == Verdict.allow
@@ -46,11 +54,8 @@ class TestClamavScanner:
         file = tmp_path / "evil.bin"
         file.write_bytes(b"\x00" * 100)
 
-        mock_result = subprocess.CompletedProcess(
-            args=[], returncode=1,
-            stdout="evil.bin: Win.Trojan.Agent-123 FOUND", stderr=""
-        )
-        with patch("subprocess.run", return_value=mock_result):
+        mock_sock = _mock_clamd_socket(b"stream: Win.Trojan.Agent-123 FOUND\0")
+        with patch("scanner.scanners.clamav.socket.create_connection", return_value=mock_sock):
             verdict, detail = clamav_scanner.scan(file)
 
         assert verdict == Verdict.block
@@ -61,28 +66,28 @@ class TestClamavScanner:
         file = tmp_path / "slow.bin"
         file.write_bytes(b"\x00")
 
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="clamdscan", timeout=30)):
+        with patch("scanner.scanners.clamav.socket.create_connection", side_effect=TimeoutError):
             verdict, detail = clamav_scanner.scan(file)
 
         assert verdict == Verdict.block
         assert detail.result == "TIMEOUT"
 
-    def test_binary_not_found(self, tmp_path):
+    def test_connection_refused(self, tmp_path):
         file = tmp_path / "test.bin"
         file.write_bytes(b"\x00")
 
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+        with patch("scanner.scanners.clamav.socket.create_connection", side_effect=ConnectionRefusedError):
             verdict, detail = clamav_scanner.scan(file)
 
         assert verdict == Verdict.block
         assert detail.result == "ERROR"
 
-    def test_error_return_code(self, tmp_path):
+    def test_unexpected_response(self, tmp_path):
         file = tmp_path / "test.bin"
         file.write_bytes(b"\x00")
 
-        mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="ERROR: some error")
-        with patch("subprocess.run", return_value=mock_result):
+        mock_sock = _mock_clamd_socket(b"stream: UNKNOWN RESPONSE\0")
+        with patch("scanner.scanners.clamav.socket.create_connection", return_value=mock_sock):
             verdict, detail = clamav_scanner.scan(file)
 
         assert verdict == Verdict.block


### PR DESCRIPTION
## Summary

- `scanner/Dockerfile`: python:3.12-slim + ClamAV + Trivy
- `scanner/entrypoint.sh`: freshclam DB 更新 + clamd 起動 + Trivy DB DL + uvicorn
- `scanner/clamd.conf`: TCP 3310, foreground mode
- `scanner/scanners/clamav.py`: clamd TCP INSTREAM プロトコルに書き換え（clamdscan が Debian パッケージに含まれないため）

Closes #4

## Test plan

- [x] `docker build` エラーなし
- [x] `GET /health` → `{"status": "healthy", "clamav": "ready", "trivy": "ready"}`
- [x] EICAR test file → `{"verdict": "block", "threat": "Eicar-Test-Signature"}`
- [x] Clean file → `{"verdict": "allow"}`
- [x] `pytest tests/` — 55 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)