### PR TITLE
feat(proxy): Dockerfile with mitmproxy and addon

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY proxy/requirements.txt /tmp/requirements.txt
+RUN uv pip install --system --no-cache -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+COPY proxy/ /opt/aegis/proxy/
+COPY scanner/models.py /opt/aegis/scanner/models.py
+COPY scanner/__init__.py /opt/aegis/scanner/__init__.py
+RUN mkdir -p /opt/aegis/rules
+
+WORKDIR /opt/aegis
+
+ENV PYTHONPATH=/opt/aegis
+
+EXPOSE 8080 8081
+
+ENTRYPOINT ["mitmdump", "--script", "/opt/aegis/proxy/aegis_addon.py", "--listen-port", "8080"]

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,3 +1,4 @@
 mitmproxy>=11.0
 httpx>=0.28
 pyyaml>=6.0
+pydantic>=2.0


### PR DESCRIPTION
## Summary

- `proxy/Dockerfile`: python:3.12-slim + uv + mitmproxy, addon ソースコピー, PYTHONPATH 設定
- `proxy/requirements.txt`: pydantic 追加 (scanner.models.Verdict 依存)
- CA 証明書: `/root/.mitmproxy/mitmproxy-ca-cert.pem` に自動生成
- ENTRYPOINT: `mitmdump --script /opt/aegis/proxy/aegis_addon.py --listen-port 8080`

Closes #7

## Test plan

- [x] `docker build` エラーなし
- [x] コンテナ起動、addon ロード成功
- [x] `curl -x http://localhost:8080 http://example.com` → 200
- [x] CA 証明書が `/root/.mitmproxy/` に生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)