### PR TITLE
feat(worker): Ubuntu + Node.js container with proxy and CA cert

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    wget \
+    git \
+    python3 \
+    ca-certificates \
+    openssl \
+    gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash aegis
+
+COPY worker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV HTTP_PROXY=http://aegis-proxy:8080 \
+    HTTPS_PROXY=http://aegis-proxy:8080 \
+    NO_PROXY=aegis-scanner,localhost,127.0.0.1
+
+WORKDIR /workspace
+
+EXPOSE 0
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["bash"]

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CERT_SRC="/certs/mitmproxy-ca-cert.pem"
+CERT_DST="/usr/local/share/ca-certificates/aegis.crt"
+
+if [ -f "$CERT_SRC" ]; then
+    cp "$CERT_SRC" "$CERT_DST"
+    update-ca-certificates --fresh > /dev/null 2>&1
+    export NODE_EXTRA_CA_CERTS="$CERT_SRC"
+fi
+
+exec gosu aegis "$@"


### PR DESCRIPTION
## Summary

- `worker/Dockerfile`: Ubuntu 24.04 + Node.js 22 LTS, non-root `aegis` user, gosu
- `worker/entrypoint.sh`: CA cert install + `update-ca-certificates` + `NODE_EXTRA_CA_CERTS`
- `HTTP_PROXY`/`HTTPS_PROXY` pre-configured

Closes #8

## Test plan

- [x] `docker build` エラーなし
- [x] non-root user `aegis` で動作
- [x] Node.js 22.x, npm 利用可能
- [x] `HTTP_PROXY`/`HTTPS_PROXY` 設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)