### PR TITLE
feat(gate): Aegis CLI wrapper (fetch/status/up/down/reload)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ requires-python = ">=3.12"
 license = { text = "MIT" }
 readme = "README.md"
 
+dependencies = [
+    "click>=8.1",
+]
+
+[project.scripts]
+aegis = "aegis.cli:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -26,4 +33,5 @@ dev = [
     "python-multipart>=0.0.20",
     "pyyaml>=6.0",
     "mitmproxy>=11.0",
+    "click>=8.1",
 ]

--- a/src/aegis/cli.py
+++ b/src/aegis/cli.py
@@ -1,0 +1,102 @@
+import json
+import subprocess
+import sys
+
+import click
+
+from aegis.config import OUTPUT_FORMAT
+from aegis.executor import compose_down, compose_up, exec_compose, fetch_url, get_service_health
+
+
+@click.group()
+def main():
+    """Aegis - Security gateway for AI agents."""
+    pass
+
+
+@main.command()
+@click.argument("url")
+@click.option("--json-output", "--json", "json_out", is_flag=True, help="Output as JSON")
+@click.option("--timeout", type=int, default=None, help="Request timeout in seconds")
+def fetch(url: str, json_out: bool, timeout: int | None):
+    """Fetch a URL through Aegis security scanning pipeline."""
+    try:
+        result = fetch_url(url, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        click.echo("Error: request timed out", err=True)
+        sys.exit(1)
+    except FileNotFoundError:
+        click.echo("Error: docker compose not found. Is Docker installed?", err=True)
+        sys.exit(1)
+
+    if json_out or OUTPUT_FORMAT == "json":
+        click.echo(json.dumps(result, indent=2))
+    else:
+        ct = result.get("content_type", "")
+        if result["verdict"] == "block":
+            click.echo(f"[BLOCK] {url} — {result.get('reason', 'blocked')}")
+        elif result["verdict"] == "warn":
+            click.echo(f"[WARN] {url} ({ct}) — {result.get('reason', '')}")
+            if result.get("content"):
+                click.echo(result["content"])
+        else:
+            size = len(result.get("content", "") or "")
+            click.echo(f"[ALLOW] {url} ({ct}, {size} bytes)")
+            if result.get("content"):
+                click.echo(result["content"])
+
+    sys.exit(0 if result["verdict"] == "allow" else 1)
+
+
+@main.command()
+@click.option("--json-output", "--json", "json_out", is_flag=True, help="Output as JSON")
+def status(json_out: bool):
+    """Check Aegis environment health status."""
+    try:
+        result = get_service_health()
+    except FileNotFoundError:
+        click.echo("Error: docker compose not found. Is Docker installed?", err=True)
+        sys.exit(1)
+
+    if json_out or OUTPUT_FORMAT == "json":
+        click.echo(json.dumps(result, indent=2))
+    else:
+        for name, info in result["services"].items():
+            status_str = info.get("status", "unknown")
+            click.echo(f"  {name}: {status_str}")
+        ready = "ready" if result["environment_ready"] else "not ready"
+        click.echo(f"\nEnvironment: {ready}")
+
+    sys.exit(0 if result["environment_ready"] else 1)
+
+
+@main.command()
+def up():
+    """Start Aegis environment."""
+    click.echo("Starting Aegis environment...")
+    output = compose_up()
+    click.echo(output)
+
+
+@main.command()
+@click.option("-v", "--volumes", is_flag=True, help="Remove volumes (full cleanup)")
+def down(volumes: bool):
+    """Stop Aegis environment."""
+    click.echo("Stopping Aegis environment...")
+    output = compose_down(volumes=volumes)
+    click.echo(output)
+
+
+@main.command()
+def reload():
+    """Reload proxy rules (hot reload via SIGHUP)."""
+    try:
+        result = exec_compose("exec", "-T", "aegis-proxy", "kill", "-HUP", "1", timeout=10)
+        if result.returncode == 0:
+            click.echo("Rules reloaded successfully")
+        else:
+            click.echo(f"Error: {result.stderr}", err=True)
+            sys.exit(1)
+    except subprocess.TimeoutExpired:
+        click.echo("Error: reload timed out", err=True)
+        sys.exit(1)

--- a/src/aegis/config.py
+++ b/src/aegis/config.py
@@ -1,0 +1,6 @@
+import os
+
+COMPOSE_FILE = os.getenv("AEGIS_COMPOSE_FILE", "./docker-compose.yml")
+COMPOSE_PROJECT = os.getenv("AEGIS_COMPOSE_PROJECT", "aegis")
+OUTPUT_FORMAT = os.getenv("AEGIS_OUTPUT_FORMAT", "text")
+TIMEOUT = int(os.getenv("AEGIS_TIMEOUT", "30"))

--- a/src/aegis/executor.py
+++ b/src/aegis/executor.py
@@ -1,0 +1,127 @@
+import json
+import subprocess
+
+from aegis.config import COMPOSE_FILE, COMPOSE_PROJECT, TIMEOUT
+
+_SEPARATOR = "\n---AEGIS_CURL_SEP---\n"
+
+
+def _compose_cmd(*args: str) -> list[str]:
+    return ["docker", "compose", "-f", COMPOSE_FILE, "-p", COMPOSE_PROJECT, *args]
+
+
+def exec_compose(*args: str, timeout: int | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        _compose_cmd(*args),
+        capture_output=True, text=True,
+        timeout=timeout or TIMEOUT,
+    )
+
+
+def compose_up() -> str:
+    result = subprocess.run(
+        _compose_cmd("up", "-d"),
+        capture_output=True, text=True, timeout=300,
+    )
+    return result.stdout + result.stderr
+
+
+def compose_down(volumes: bool = False) -> str:
+    cmd = _compose_cmd("down")
+    if volumes:
+        cmd.append("-v")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    return result.stdout + result.stderr
+
+
+def compose_ps() -> str:
+    result = subprocess.run(
+        _compose_cmd("ps", "--format", "table {{.Name}}\t{{.Status}}"),
+        capture_output=True, text=True, timeout=10,
+    )
+    return result.stdout
+
+
+def exec_in_worker(command: list[str], timeout: int | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        _compose_cmd("exec", "-T", "aegis-worker", *command),
+        capture_output=True, text=True,
+        timeout=timeout or TIMEOUT,
+    )
+
+
+def fetch_url(url: str, timeout: int | None = None) -> dict:
+    """Fetch a URL through aegis-worker and return structured result."""
+    # Use a unique separator to avoid ambiguity with body content
+    result = exec_in_worker(
+        ["curl", "-s",
+         "-w", f"{_SEPARATOR}%{{http_code}}{_SEPARATOR}%{{content_type}}",
+         "-D", "/dev/stderr", "-o", "-", url],
+        timeout=timeout,
+    )
+
+    parts = result.stdout.rsplit(_SEPARATOR.strip(), 2)
+    if len(parts) >= 3:
+        body = parts[0].rstrip("\n")
+        status_code = int(parts[1].strip()) if parts[1].strip().isdigit() else 0
+        content_type = parts[2].strip()
+    else:
+        body = result.stdout
+        status_code = 0
+        content_type = ""
+
+    headers = result.stderr
+    verdict = "allow"
+    reason = None
+    if status_code == 403 and "aegis" in headers.lower():
+        verdict = "block"
+        try:
+            reason_data = json.loads(body)
+            reason = reason_data.get("reason", "blocked by proxy")
+        except (json.JSONDecodeError, ValueError):
+            reason = "blocked by proxy"
+        body = None
+
+    if "X-Aegis-Warning" in headers:
+        verdict = "warn"
+        reason = "medium-risk vulnerability detected"
+
+    return {
+        "url": url,
+        "status_code": status_code,
+        "verdict": verdict,
+        "reason": reason,
+        "content_type": content_type,
+        "content": body if verdict != "block" else None,
+    }
+
+
+def get_service_health() -> dict:
+    """Get health status of all aegis services."""
+    ps_output = compose_ps()
+    services = {}
+    for line in ps_output.strip().splitlines()[1:]:  # skip header
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            name, status = parts
+            services[name] = {"status": status}
+
+    try:
+        result = exec_in_worker(
+            ["curl", "-sf", "http://aegis-scanner:8080/health"],
+            timeout=5,
+        )
+        if result.returncode == 0:
+            scanner_health = json.loads(result.stdout)
+            services["aegis-scanner"] = scanner_health
+    except Exception:
+        pass
+
+    return {
+        "services": services,
+        "environment_ready": bool(services) and all(
+            "healthy" in str(s.get("status", "")).lower()
+            or s.get("status") == "healthy"
+            for s in services.values()
+        ),
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,105 @@
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from aegis.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_fetch_allow(runner):
+    mock_result = {
+        "url": "https://example.com",
+        "status_code": 200,
+        "verdict": "allow",
+        "reason": None,
+        "content_type": "text/html",
+        "content": "<html>hello</html>",
+    }
+    with patch("aegis.cli.fetch_url", return_value=mock_result):
+        result = runner.invoke(main, ["fetch", "https://example.com"])
+    assert result.exit_code == 0
+    assert "[ALLOW]" in result.output
+
+
+def test_fetch_block(runner):
+    mock_result = {
+        "url": "https://evil.com/malware",
+        "status_code": 403,
+        "verdict": "block",
+        "reason": "dangerous_script_pattern",
+        "content_type": "text/x-shellscript",
+        "content": None,
+    }
+    with patch("aegis.cli.fetch_url", return_value=mock_result):
+        result = runner.invoke(main, ["fetch", "https://evil.com/malware"])
+    assert result.exit_code == 1
+    assert "[BLOCK]" in result.output
+
+
+def test_fetch_json_output(runner):
+    mock_result = {
+        "url": "https://example.com",
+        "status_code": 200,
+        "verdict": "allow",
+        "reason": None,
+        "content_type": "text/html",
+        "content": "<html></html>",
+    }
+    with patch("aegis.cli.fetch_url", return_value=mock_result):
+        result = runner.invoke(main, ["fetch", "--json", "https://example.com"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["verdict"] == "allow"
+
+
+def test_fetch_timeout(runner):
+    with patch("aegis.cli.fetch_url", side_effect=subprocess.TimeoutExpired(cmd="curl", timeout=30)):
+        result = runner.invoke(main, ["fetch", "https://example.com"])
+    assert result.exit_code == 1
+    assert "timed out" in result.output
+
+
+def test_status_ready(runner):
+    mock_health = {
+        "services": {
+            "aegis-scanner": {"status": "Up 30s (healthy)"},
+            "aegis-proxy": {"status": "Up 20s (healthy)"},
+            "aegis-worker": {"status": "Up 10s"},
+        },
+        "environment_ready": True,
+    }
+    with patch("aegis.cli.get_service_health", return_value=mock_health):
+        result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "ready" in result.output
+
+
+def test_status_json(runner):
+    mock_health = {
+        "services": {"aegis-scanner": {"status": "healthy"}},
+        "environment_ready": True,
+    }
+    with patch("aegis.cli.get_service_health", return_value=mock_health):
+        result = runner.invoke(main, ["status", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["environment_ready"] is True
+
+
+def test_up(runner):
+    with patch("aegis.cli.compose_up", return_value="Started"):
+        result = runner.invoke(main, ["up"])
+    assert result.exit_code == 0
+
+
+def test_down(runner):
+    with patch("aegis.cli.compose_down", return_value="Stopped"):
+        result = runner.invoke(main, ["down"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- `src/aegis/cli.py`: Click CLI — `aegis fetch`, `status`, `up`, `down`, `reload`
- `src/aegis/executor.py`: Docker Compose exec wrapper, URL fetch + header parsing
- `src/aegis/config.py`: 環境変数設定 (COMPOSE_FILE, TIMEOUT 等)
- `pyproject.toml`: click 依存 + `[project.scripts]` エントリポイント
- `tests/test_cli.py`: 8 テスト

Closes #12

## Test plan

- [x] `pytest tests/` — 79 tests passed
- [x] `aegis --help` — 全コマンド表示
- [x] `aegis fetch --json` — JSON 出力
- [x] block 時は exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)