### PR TITLE
feat(gate): MCP Server for Claude Code integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 dependencies = [
     "click>=8.1",
+    "mcp>=1.0",
 ]
 
 [project.scripts]
@@ -34,4 +35,6 @@ dev = [
     "pyyaml>=6.0",
     "mitmproxy>=11.0",
     "click>=8.1",
+    "mcp>=1.0",
+    "pytest-asyncio>=0.24",
 ]

--- a/src/aegis/cli.py
+++ b/src/aegis/cli.py
@@ -100,3 +100,12 @@ def reload():
     except subprocess.TimeoutExpired:
         click.echo("Error: reload timed out", err=True)
         sys.exit(1)
+
+
+@main.command("mcp-server")
+def mcp_server():
+    """Start Aegis MCP Server (stdio transport for Claude Code)."""
+    # Lazy import: mcp is a heavy dependency, only load when this command is used
+    import asyncio
+    from aegis.mcp_server import run
+    asyncio.run(run())

--- a/src/aegis/mcp_server.py
+++ b/src/aegis/mcp_server.py
@@ -1,0 +1,136 @@
+import asyncio
+import json
+import subprocess
+from functools import partial
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from aegis.executor import exec_in_worker, fetch_url, get_service_health
+
+server = Server("aegis")
+
+
+@server.list_tools()
+async def list_tools():
+    return [
+        Tool(
+            name="aegis_fetch",
+            description=(
+                "Fetch a URL through Aegis security scanning pipeline. "
+                "IMPORTANT behavior rules based on verdict: "
+                "verdict 'allow': Safe content. Proceed without asking the user. "
+                "verdict 'warn': Potential risk detected. Show the warning details "
+                "to the user and ask for confirmation (Y/N) before using the content. "
+                "verdict 'block': Threat detected. Show the block reason and scan "
+                "details to the user and ask for confirmation (Y/N) before proceeding. "
+                "Do NOT use blocked content unless the user explicitly approves."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string", "description": "URL to fetch"},
+                    "method": {"type": "string", "description": "HTTP method", "default": "GET"},
+                },
+                "required": ["url"],
+            },
+        ),
+        Tool(
+            name="aegis_status",
+            description="Check the health status of all Aegis services (scanner, proxy, worker).",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+        Tool(
+            name="aegis_update",
+            description="Update definition databases (ClamAV, Trivy, C2 blocklist).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "targets": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["clamav", "trivy", "c2"]},
+                        "description": "Which databases to update. Omit to update all.",
+                    },
+                },
+            },
+        ),
+    ]
+
+
+async def _run_sync(fn, *args, **kwargs):
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, partial(fn, *args, **kwargs))
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict):
+    if name == "aegis_fetch":
+        return await _handle_fetch(arguments)
+    elif name == "aegis_status":
+        return await _handle_status()
+    elif name == "aegis_update":
+        return await _handle_update(arguments)
+    else:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+
+async def _handle_fetch(arguments: dict) -> list[TextContent]:
+    url = arguments["url"]
+    try:
+        result = await _run_sync(fetch_url, url)
+    except subprocess.TimeoutExpired:
+        return [TextContent(type="text", text=json.dumps({
+            "url": url, "verdict": "block", "reason": "request timed out",
+        }))]
+    except FileNotFoundError:
+        return [TextContent(type="text", text=json.dumps({
+            "url": url, "verdict": "block",
+            "reason": "Docker Compose not found. Is the Aegis environment running?",
+        }))]
+
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def _handle_status() -> list[TextContent]:
+    try:
+        result = await _run_sync(get_service_health)
+    except FileNotFoundError:
+        result = {"services": {}, "environment_ready": False}
+
+    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+def _update_target(target: str) -> dict:
+    try:
+        r = exec_in_worker(
+            ["curl", "-sf", "-X", "POST", "http://aegis-scanner:8080/update",
+             "-H", "Content-Type: application/json",
+             "-d", json.dumps({"targets": [target]})],
+            timeout=120,
+        )
+        return {"status": "updated" if r.returncode == 0 else "failed"}
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout"}
+
+
+async def _handle_update(arguments: dict) -> list[TextContent]:
+    targets = arguments.get("targets", ["clamav", "trivy", "c2"])
+    results = {}
+
+    for target in ["clamav", "trivy"]:
+        if target in targets:
+            results[target] = await _run_sync(_update_target, target)
+
+    if "c2" in targets:
+        results["c2_blocklist"] = {"status": "not_implemented"}
+
+    return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
+
+async def run():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,83 @@
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from aegis.mcp_server import _handle_fetch, _handle_status, _handle_update, list_tools
+
+
+@pytest.mark.asyncio
+async def test_list_tools():
+    tools = await list_tools()
+    names = [t.name for t in tools]
+    assert "aegis_fetch" in names
+    assert "aegis_status" in names
+    assert "aegis_update" in names
+
+
+@pytest.mark.asyncio
+async def test_fetch_allow():
+    mock_result = {
+        "url": "https://example.com",
+        "status_code": 200,
+        "verdict": "allow",
+        "reason": None,
+        "content_type": "text/html",
+        "content": "<html>hello</html>",
+    }
+    with patch("aegis.mcp_server.fetch_url", return_value=mock_result):
+        result = await _handle_fetch({"url": "https://example.com"})
+
+    assert len(result) == 1
+    data = json.loads(result[0].text)
+    assert data["verdict"] == "allow"
+
+
+@pytest.mark.asyncio
+async def test_fetch_block():
+    mock_result = {
+        "url": "https://evil.com/malware",
+        "status_code": 403,
+        "verdict": "block",
+        "reason": "dangerous_script_pattern",
+        "content_type": "text/x-shellscript",
+        "content": None,
+    }
+    with patch("aegis.mcp_server.fetch_url", return_value=mock_result):
+        result = await _handle_fetch({"url": "https://evil.com/malware"})
+
+    data = json.loads(result[0].text)
+    assert data["verdict"] == "block"
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeout():
+    with patch("aegis.mcp_server.fetch_url", side_effect=subprocess.TimeoutExpired(cmd="curl", timeout=30)):
+        result = await _handle_fetch({"url": "https://slow.com"})
+
+    data = json.loads(result[0].text)
+    assert data["verdict"] == "block"
+    assert "timed out" in data["reason"]
+
+
+@pytest.mark.asyncio
+async def test_status():
+    mock_health = {
+        "services": {"aegis-scanner": {"status": "healthy"}},
+        "environment_ready": True,
+    }
+    with patch("aegis.mcp_server.get_service_health", return_value=mock_health):
+        result = await _handle_status()
+
+    data = json.loads(result[0].text)
+    assert data["environment_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_docker_not_found():
+    with patch("aegis.mcp_server.get_service_health", side_effect=FileNotFoundError):
+        result = await _handle_status()
+
+    data = json.loads(result[0].text)
+    assert data["environment_ready"] is False


### PR DESCRIPTION
## Summary

- `src/aegis/mcp_server.py`: MCP Server (stdio transport)
  - `aegis_fetch`: URL 取得 + verdict ベースの振る舞いルール (description に記載)
  - `aegis_status`: サービスヘルスチェック
  - `aegis_update`: 定義 DB 更新トリガー
- `src/aegis/cli.py`: `mcp-server` サブコマンド追加
- `pyproject.toml`: mcp, pytest-asyncio 依存追加
- `tests/test_mcp_server.py`: 6 テスト

Claude Code 設定:
```json
{"mcpServers": {"aegis": {"command": "aegis", "args": ["mcp-server"]}}}
```

Closes #13

## Test plan

- [x] `pytest tests/` — 85 tests passed
- [x] `aegis mcp-server` が起動
- [x] aegis_fetch: allow/block/timeout テスト
- [x] aegis_status: healthy/docker not found テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)