### PR TITLE
Fix pids_limit conflict with Docker Compose v2.40+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,12 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    pids_limit: 64
     deploy:
       resources:
         limits:
           memory: 2G
           cpus: "1.0"
+          pids: 64
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
@@ -60,12 +60,12 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    pids_limit: 64
     deploy:
       resources:
         limits:
           memory: 1G
           cpus: "1.0"
+          pids: 64
     healthcheck:
       test: ["CMD", "curl", "-f", "-x", "http://localhost:8080", "http://example.com"]
       interval: 30s
@@ -105,7 +105,6 @@ services:
     cap_add:
       - SETUID   # required for gosu user switch in entrypoint
       - SETGID
-    pids_limit: 128
     dns:
       - 127.0.0.11
     deploy:
@@ -113,6 +112,7 @@ services:
         limits:
           memory: 4G
           cpus: "2.0"
+          pids: 128
     stdin_open: true
     tty: true
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Docker Compose v2.40+ で `pids_limit`（レガシー）と `deploy.resources.limits` の併用がエラーになる問題を修正
- 3サービス（scanner, proxy, worker）の `pids_limit` を `deploy.resources.limits.pids` に移行
- PID 制限値は変更なし（scanner: 64, proxy: 64, worker: 128）

## Test plan
- [x] `docker compose config --quiet` でバリデーション通過を確認
- [ ] `docker compose up -d` で全サービスが正常起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)