### PR TITLE
fix: freshclam initgroups() failure with dropped capabilities

### DIFF
--- a/scanner/entrypoint.sh
+++ b/scanner/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 DB_DIR="/var/lib/clamav"
 if [ ! -f "$DB_DIR/main.cvd" ] && [ ! -f "$DB_DIR/main.cld" ]; then
     echo "ClamAV DB not found, running freshclam..."
-    if ! freshclam --quiet; then
+    if ! freshclam --quiet --foreground --user=root; then
         echo "ERROR: freshclam failed and no existing DB available"
         exit 1
     fi
@@ -13,7 +13,7 @@ else
     DB_AGE=$(( $(date +%s) - $(stat -c %Y "$DB_DIR/main.cvd" 2>/dev/null || stat -c %Y "$DB_DIR/main.cld" 2>/dev/null || echo 0) ))
     if [ "$DB_AGE" -gt "$INTERVAL" ]; then
         echo "ClamAV DB is stale ($DB_AGE seconds old), updating..."
-        freshclam --quiet || echo "Warning: freshclam failed, using existing DB"
+        freshclam --quiet --foreground --user=root || echo "Warning: freshclam failed, using existing DB"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Add `--foreground --user=root` flags to both `freshclam` invocations in `scanner/entrypoint.sh`
- Prevents freshclam from attempting user switch (which requires `CAP_SETUID`/`CAP_SETGID` dropped by security hardening)

Closes #29

## Test plan

- [ ] `docker compose up -d --build` succeeds without freshclam errors
- [ ] ClamAV DB downloads correctly on first run (empty volume)
- [ ] Stale DB update path works correctly
- [ ] `make test` passes (85/85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)