### PR TITLE
fix: worker crash due to read-only filesystem CA cert write

### DIFF
--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -2,12 +2,12 @@
 set -e
 
 CERT_SRC="/certs/mitmproxy-ca-cert.pem"
-CERT_DST="/usr/local/share/ca-certificates/aegis.crt"
 
 if [ -f "$CERT_SRC" ]; then
-    cp "$CERT_SRC" "$CERT_DST"
-    update-ca-certificates --fresh > /dev/null 2>&1
+    # System CA store is read-only; configure per-runtime CA trust instead
     export NODE_EXTRA_CA_CERTS="$CERT_SRC"
+    export SSL_CERT_FILE="$CERT_SRC"
+    export REQUESTS_CA_BUNDLE="$CERT_SRC"
 fi
 
 exec gosu aegis "$@"


### PR DESCRIPTION
## Summary

- `aegis-worker` が `read_only: true` 環境で起動時にクラッシュし続けていた
- `entrypoint.sh` が `/usr/local/share/ca-certificates/` への `cp` と `update-ca-certificates` を実行しており、read-only filesystem でエラー
- システム CA ストアへの書き込みを廃止し、環境変数（`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`）による per-runtime CA 信頼設定に変更

## Test plan

- [ ] `docker compose up -d --build` で aegis-worker が正常起動する
- [ ] worker コンテナから HTTPS リクエストが mitmproxy 経由で通る
- [ ] `make test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)