### PR TITLE
fix: worker TLS failure due to missing system CAs in bundle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,9 @@ services:
       HTTPS_PROXY: "http://aegis-proxy:8080"
       NO_PROXY: "aegis-scanner,localhost,127.0.0.1"
       NODE_EXTRA_CA_CERTS: "/certs/mitmproxy-ca-cert.pem"
+      SSL_CERT_FILE: "/tmp/ca-bundle.crt"
+      REQUESTS_CA_BUNDLE: "/tmp/ca-bundle.crt"
+      CURL_CA_BUNDLE: "/tmp/ca-bundle.crt"
     read_only: true
     tmpfs:
       - /tmp:size=100M,noexec,nosuid

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -2,12 +2,15 @@
 set -e
 
 CERT_SRC="/certs/mitmproxy-ca-cert.pem"
+COMBINED_CA="/tmp/ca-bundle.crt"
 
 if [ -f "$CERT_SRC" ]; then
-    # System CA store is read-only; configure per-runtime CA trust instead
+    # System CA store is read-only; build a combined bundle in tmpfs
+    cat /etc/ssl/certs/ca-certificates.crt "$CERT_SRC" > "$COMBINED_CA"
+    export SSL_CERT_FILE="$COMBINED_CA"
+    export REQUESTS_CA_BUNDLE="$COMBINED_CA"
+    export CURL_CA_BUNDLE="$COMBINED_CA"
     export NODE_EXTRA_CA_CERTS="$CERT_SRC"
-    export SSL_CERT_FILE="$CERT_SRC"
-    export REQUESTS_CA_BUNDLE="$CERT_SRC"
 fi
 
 exec gosu aegis "$@"


### PR DESCRIPTION
## Summary

- PR #31 の修正で mitmproxy CA のみを `SSL_CERT_FILE` に設定していたため、外部サイトへの HTTPS 接続が全て失敗していた
- `entrypoint.sh` でシステム CA バンドル + mitmproxy CA を `/tmp/ca-bundle.crt` に結合するよう修正
- `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE` を `docker-compose.yml` の環境変数に設定し、`docker compose exec` セッションでも有効にした

## Test plan

- [x] `make test` パス (85/85)
- [x] `aegis fetch https://note.com/...` で status_code 200、verdict allow を確認済み
- [ ] worker コンテナが再起動ループに入らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)