### PR TITLE
fix: handle non-UTF-8 encoded responses in fetch_url

### DIFF
--- a/src/aegis/executor.py
+++ b/src/aegis/executor.py
@@ -43,10 +43,16 @@ def compose_ps() -> str:
 
 
 def exec_in_worker(command: list[str], timeout: int | None = None) -> subprocess.CompletedProcess:
-    return subprocess.run(
+    result = subprocess.run(
         _compose_cmd("exec", "-T", "aegis-worker", *command),
-        capture_output=True, text=True,
+        capture_output=True,
         timeout=timeout or TIMEOUT,
+    )
+    return subprocess.CompletedProcess(
+        args=result.args,
+        returncode=result.returncode,
+        stdout=result.stdout.decode("utf-8", errors="replace"),
+        stderr=result.stderr.decode("utf-8", errors="replace"),
     )
 
 


### PR DESCRIPTION
## Summary
- `exec_in_worker` used `text=True` which enforces strict UTF-8 decoding, causing crashes on pages with non-UTF-8 encodings (e.g. Shift_JIS)
- Changed to read raw bytes and decode with `errors="replace"` so undecodable bytes become `�` instead of raising an exception

## Test plan
- [x] All 110 unit tests pass
- [ ] Verify `aegis fetch https://www.itmedia.co.jp/news/articles/2603/18/news037.html` returns content without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)